### PR TITLE
fix: start menu quitting

### DIFF
--- a/src/CLInterface.py
+++ b/src/CLInterface.py
@@ -41,6 +41,11 @@ class Interface:
     def prompt(self, options: list) -> str:
         terminal_menu = TerminalMenu(options)
         menu_entry_index = terminal_menu.show()
+
+        if menu_entry_index is None:
+            print("Bye")
+            exit(0)
+
         return options[menu_entry_index]
 
     def welcome_user(self) -> None:

--- a/src/CLInterface.py
+++ b/src/CLInterface.py
@@ -44,7 +44,7 @@ class Interface:
 
         if menu_entry_index is None:
             print("Bye")
-            exit(0)
+            sys.exit(0)
 
         return options[menu_entry_index]
 


### PR DESCRIPTION
Qurrently when pressing `q` or `<Ctrl>-C` the program throws an exception.
Reason for this is that on those two cases `terminal_menu.show()` returns `None` instead of a valid index.

Therefore I decided to add a simple `Bye` message and then exit. Ideas improving this handling are welcome :)