### PR TITLE
fix: handle Request.set_api() errors

### DIFF
--- a/src/request.py
+++ b/src/request.py
@@ -1,3 +1,4 @@
+import sys
 from oauthlib.oauth2 import BackendApplicationClient
 from requests_oauthlib import OAuth2Session
 import os
@@ -13,17 +14,33 @@ class Request:
         dotenv.load_dotenv()
 
         client_secret = os.getenv("API_SECRET")
-        if client_secret is None:
-            raise ValueError('error: .env variable "API_SECRET" not found')
         client_id = os.getenv("API_UID")
-        if client_id is None:
-            raise ValueError('error: .env variable "API_UID" not found')
+        if client_secret is None or client_id is None:
+            missing_vars = []
+            if client_secret is None:
+                missing_vars.append("API_SECRET")
+            if client_id is None:
+                missing_vars.append("API_UID")
+            missing_vars = ", ".join(missing_vars)
+
+            print(f"Error: There are some env variables missing: {missing_vars}")
+
+            sys.exit(1)
+
         client = BackendApplicationClient(client_id=client_id)
         api = OAuth2Session(client=client)
 
-        api.fetch_token(
-            token_url="https://api.intra.42.fr/oauth/token",
-            client_id=client_id,
-            client_secret=client_secret,
-        )
+        try:
+            api.fetch_token(
+                token_url="https://api.intra.42.fr/oauth/token",
+                client_id=client_id,
+                client_secret=client_secret,
+            )
+        except:
+            print(
+                "Failed to get access token.\nAre you sure that you provided the correct Id and Secret?"
+            )
+
+            sys.exit(1)
+
         return api


### PR DESCRIPTION
Added error handling for when env variables are missing. I decided to just exit the program, since without those it cannot run anyways.
Not fully satisfied with how the missing message gets created, but yea.

Also added error handling for when `client_id`, or `client_secret` are invalid, which causes the `api.fetch_token()` to throw an exception.