### PR TITLE
refactor: don't print result in Interface

### DIFF
--- a/src/CLInterface.py
+++ b/src/CLInterface.py
@@ -1,5 +1,6 @@
 import logging
 from simple_term_menu import TerminalMenu
+from src.InterfaceResult import InterfaceResult
 from src.modules.base import BaseModule
 import sys
 
@@ -40,13 +41,18 @@ class Interface:
                 sys.exit(1)
 
             try:
-                # TODO: The module should print the result itself
                 result = self.modules[selection].run()
 
-                if result is None:
+                if result == InterfaceResult.Exit:
+                    sys.exit(0)
+
+                if result == InterfaceResult.Skip:
                     continue
 
-                self.show_result(result)
+                selection = self.prompt(["go back", "quit"])
+                if selection == "quit" or selection == None:
+                    sys.exit(0)
+
             except Exception as error:
                 self.error(error)
 

--- a/src/InterfaceResult.py
+++ b/src/InterfaceResult.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class InterfaceResult(Enum):
+    Exit = 0
+    Skip = 1
+    Success = 2

--- a/src/modules/analyze_feedback.py
+++ b/src/modules/analyze_feedback.py
@@ -1,5 +1,6 @@
+from src.InterfaceResult import InterfaceResult
 from src.modules.base import BaseModule
-from src.utils import Utils
+from src.utils import Utils, clear_terminal
 from src.animation_utils import Animation
 import threading
 from textblob import TextBlob
@@ -64,4 +65,10 @@ class FeedbackAnalyzer(BaseModule):
                 negative_comments.append(comment)
         loading_animation.stop_animation()
         formatted_negative_comments = "\n-\n".join(negative_comments)
-        return f"{len(negative_comments)} negative comments found:\n-\n{formatted_negative_comments}"
+
+        clear_terminal()
+        print(
+            f"{len(negative_comments)} negative comments found:\n-\n{formatted_negative_comments}"
+        )
+
+        return InterfaceResult.Success

--- a/src/modules/base.py
+++ b/src/modules/base.py
@@ -1,6 +1,8 @@
 from simple_term_menu import TerminalMenu
 import logging
 
+from src.InterfaceResult import InterfaceResult
+
 
 class BaseModule:
     def __init__(self, api):
@@ -12,5 +14,5 @@ class BaseModule:
         menu_entry_index = terminal_menu.show()
         return options[menu_entry_index]
 
-    def run(self):
+    def run(self) -> InterfaceResult.Success:
         raise NotImplementedError

--- a/src/modules/evaluator_score.py
+++ b/src/modules/evaluator_score.py
@@ -1,5 +1,6 @@
+from src.InterfaceResult import InterfaceResult
 from src.modules.base import BaseModule
-from src.utils import Utils
+from src.utils import Utils, clear_terminal
 import threading
 from src.animation_utils import Animation
 
@@ -26,4 +27,7 @@ class EvaluatorScore(BaseModule):
         finally:
             loading_animation.stop_animation()
 
-        return return_message
+        clear_terminal()
+        print(return_message)
+
+        return InterfaceResult.Success

--- a/src/modules/feature_request.py
+++ b/src/modules/feature_request.py
@@ -1,7 +1,15 @@
+from src.InterfaceResult import InterfaceResult
 from src.modules.base import BaseModule
+from src.utils import clear_terminal
 
 
 class FeatureRequest(BaseModule):
 
     def run(self) -> str:
-        return "for feature requests, please open an issue: https://github.com/42-stats/42-stats/issues/"
+
+        clear_terminal()
+        print(
+            "for feature requests, please open an issue: https://github.com/42-stats/42-stats/issues/"
+        )
+
+        return InterfaceResult.Success

--- a/src/modules/friends_evals.py
+++ b/src/modules/friends_evals.py
@@ -1,5 +1,6 @@
+from src.InterfaceResult import InterfaceResult
 from src.modules.base import BaseModule
-from src.utils import Utils
+from src.utils import Utils, clear_terminal
 from src.animation_utils import Animation
 from collections import Counter
 import pandas as pd
@@ -65,8 +66,12 @@ class FriendsEval(BaseModule):
         os.system("clear")
         print(self.get_top_10(login_counts, login))
         if self.prompt(["get full list", "go back"]) == "go back":
-            return "skip"
-        return self.format_result(login_counts, login)
+            clear_terminal()
+            return InterfaceResult.Skip
+
+        clear_terminal()
+        print(self.format_result(login_counts, login))
+        return InterfaceResult.Success
 
     def run(self) -> str:
         login = input("Login: ")

--- a/src/modules/odds_of_failing.py
+++ b/src/modules/odds_of_failing.py
@@ -1,5 +1,6 @@
+from src.InterfaceResult import InterfaceResult
 from src.modules.base import BaseModule
-from src.utils import Utils
+from src.utils import Utils, clear_terminal
 import threading
 from src.animation_utils import Animation
 
@@ -24,4 +25,7 @@ class OddsOfFailing(BaseModule):
         finally:
             loading_animation.stop_animation()
 
-        return return_message
+        clear_terminal()
+        print(return_message)
+
+        return InterfaceResult.Success


### PR DESCRIPTION
Continuing on making Interface more usable throughout the entire codebase I moved the printing of the result from the interface to the module itself.

Right now it is still a bit ugly, but this issue will be addressed SoonTM.