### PR TITLE
fix: use custom prompt function

### DIFF
--- a/src/modules/analyze_feedback.py
+++ b/src/modules/analyze_feedback.py
@@ -1,5 +1,5 @@
 from src.modules.base import BaseModule
-from src.utils import Utils
+from src.utils import Utils, prompt
 from src.animation_utils import Animation
 import threading
 from textblob import TextBlob
@@ -36,7 +36,7 @@ class FeedbackAnalyzer(BaseModule):
             "\rDo (very) basic language processing to list the negative comments you have received\n"
         )
         side = self.prompt(["as corrector?", "as corrected?"])
-        login = input("\rlogin: ")
+        login = prompt("\rlogin: ")
         side = side.replace(" ", "_")
         try:
             loading_animation = Animation(f"Fetching evaluation for user: {login}")

--- a/src/modules/evaluator_score.py
+++ b/src/modules/evaluator_score.py
@@ -1,5 +1,5 @@
 from src.modules.base import BaseModule
-from src.utils import Utils
+from src.utils import Utils, prompt
 import threading
 from src.animation_utils import Animation
 
@@ -7,7 +7,7 @@ from src.animation_utils import Animation
 class EvaluatorScore(BaseModule):
 
     def run(self) -> str:
-        login = input("login: ")
+        login = prompt("login: ")
         loading_animation = Animation(
             f"Fetching evaluations involving {login} as a corrector"
         )

--- a/src/modules/friends_evals.py
+++ b/src/modules/friends_evals.py
@@ -1,5 +1,5 @@
 from src.modules.base import BaseModule
-from src.utils import Utils
+from src.utils import Utils, prompt
 from src.animation_utils import Animation
 from collections import Counter
 import pandas as pd
@@ -69,7 +69,7 @@ class FriendsEval(BaseModule):
         return self.format_result(login_counts, login)
 
     def run(self) -> str:
-        login = input("Login: ")
+        login = prompt("Login: ")
         try:
             loading_animation = Animation(f"Fetching all evaluations involving {login}")
             user_id = Utils.get_user_id(self.api, login)

--- a/src/modules/odds_of_failing.py
+++ b/src/modules/odds_of_failing.py
@@ -1,5 +1,5 @@
 from src.modules.base import BaseModule
-from src.utils import Utils
+from src.utils import Utils, prompt
 import threading
 from src.animation_utils import Animation
 
@@ -7,7 +7,7 @@ from src.animation_utils import Animation
 class OddsOfFailing(BaseModule):
 
     def run(self) -> str:
-        login = input("login: ")
+        login = prompt("login: ")
         loading_animation = Animation(f"Fetching groups for {login}")
 
         try:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from requests_oauthlib import OAuth2Session
 import pandas as pd
 import json
@@ -8,6 +9,15 @@ import time
 def clear_terminal():
     # Since Windows likes to be special the command is `cls` and not `clear`
     os.system("cls" if os.name == "nt" else "clear")
+
+
+def prompt(message: str):
+    try:
+        return input(message)
+    except EOFError:
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(1)
 
 
 class Utils:


### PR DESCRIPTION
Pythons `input` function handles `ctrl+c`, and `ctrl+d` by throwing an exception.
Therefore I've added `prompt` which catches those errors and does a `sys.exit()` instead.