### PR TITLE
fix: `OddsOfFailing` bonus marks

### DIFF
--- a/src/modules/odds_of_failing.py
+++ b/src/modules/odds_of_failing.py
@@ -16,7 +16,7 @@ class OddsOfFailing(BaseModule):
                 api=self.api, user_id=user_id, side="as_corrected"
             )
             evals = evals.dropna(subset=["final_mark"])
-            average = evals["final_mark"].mean()
+            average = evals["final_mark"].clip(upper=100).mean()
             result = 100 - average
             return_message = f"\rresult: {round(result, 2)}%\n"
         except Exception as e:


### PR DESCRIPTION
Currently the `OddsOfFailing` does not take bonus marks into account, so makrs which can go over `100`, leading to incorrect results. The easiest way to takle this issue is to cap the mark just to `100`. But maybe we can come up with a more sophisticated formula which takes bonus points into account too 🤔.