### PR TITLE
feat: add `prompt_select`

### DIFF
--- a/src/CLInterface.py
+++ b/src/CLInterface.py
@@ -4,7 +4,7 @@ from src.InterfaceResult import InterfaceResult
 from src.modules.base import BaseModule
 import sys
 
-from src.utils import clear_terminal
+from src.utils import clear_terminal, prompt_select
 
 
 class Interface:
@@ -24,7 +24,7 @@ class Interface:
             clear_terminal()
             print(self.title)
 
-            selection = self.prompt(options)
+            selection = prompt_select(options)
 
             if selection == "quit":
                 clear_terminal()
@@ -49,7 +49,7 @@ class Interface:
                 if result == InterfaceResult.Skip:
                     continue
 
-                selection = self.prompt(["go back", "quit"])
+                selection = prompt_select(["go back", "quit"])
                 if selection == "quit" or selection == None:
                     sys.exit(0)
 
@@ -62,26 +62,15 @@ class Interface:
         print(result)
 
         # TODO: better solution for this
-        if result != "skip" and self.prompt(["go back", "quit"]) == "quit":
+        if result != "skip" and prompt_select(["go back", "quit"]) == "quit":
             clear_terminal()
             sys.exit(0)
 
     def error(self, error: Exception):
         self.logs.error(f"We have encountered an unhandled error:\n{error}\n")
 
-        if self.prompt(["continue", "quit"]) == "continue":
+        if prompt_select(["continue", "quit"]) == "continue":
             return
 
         print("Bye")
         sys.exit(1)
-
-    def prompt(self, options: list[str]) -> str:
-        terminal_menu = TerminalMenu(options)
-        menu_entry_index = terminal_menu.show()
-
-        if menu_entry_index is None:
-            clear_terminal()
-            print("Bye")
-            sys.exit(0)
-
-        return options[menu_entry_index]

--- a/src/modules/analyze_feedback.py
+++ b/src/modules/analyze_feedback.py
@@ -1,6 +1,6 @@
 from src.InterfaceResult import InterfaceResult
 from src.modules.base import BaseModule
-from src.utils import Utils, prompt
+from src.utils import Utils, prompt, prompt_select
 from src.animation_utils import Animation
 import threading
 from textblob import TextBlob
@@ -36,7 +36,7 @@ class FeedbackAnalyzer(BaseModule):
         print(
             "\rDo (very) basic language processing to list the negative comments you have received\n"
         )
-        side = self.prompt(["as corrector?", "as corrected?"])
+        side = prompt_select(["as corrector?", "as corrected?"])
         login = prompt("\rlogin: ")
         side = side.replace(" ", "_")
         try:

--- a/src/modules/base.py
+++ b/src/modules/base.py
@@ -9,10 +9,5 @@ class BaseModule:
         self.api = api
         self.logs = logging.getLogger("logs")
 
-    def prompt(self, options: list):
-        terminal_menu = TerminalMenu(options)
-        menu_entry_index = terminal_menu.show()
-        return options[menu_entry_index]
-
     def run(self) -> InterfaceResult.Success:
         raise NotImplementedError

--- a/src/modules/friends_evals.py
+++ b/src/modules/friends_evals.py
@@ -1,6 +1,6 @@
 from src.InterfaceResult import InterfaceResult
 from src.modules.base import BaseModule
-from src.utils import Utils, prompt
+from src.utils import Utils, prompt, prompt_select
 from src.animation_utils import Animation
 from collections import Counter
 import pandas as pd
@@ -65,7 +65,7 @@ class FriendsEval(BaseModule):
     def show_formatted_result(self, login_counts, login):
         os.system("clear")
         print(self.get_top_10(login_counts, login))
-        if self.prompt(["get full list", "go back"]) == "go back":
+        if prompt_select(["get full list", "go back"]) == "go back":
             clear_terminal()
             return InterfaceResult.Skip
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,6 +4,7 @@ from requests_oauthlib import OAuth2Session
 import pandas as pd
 import json
 import time
+from simple_term_menu import TerminalMenu
 
 
 def clear_terminal():
@@ -18,6 +19,23 @@ def prompt(message: str):
         sys.exit(1)
     except KeyboardInterrupt:
         sys.exit(1)
+
+
+def prompt_select(options: list, **kwargs):
+    menu = TerminalMenu(
+        options,
+        menu_cursor="❯ ",
+        menu_cursor_style=("fg_cyan", "bold"),
+        menu_highlight_style=("bg_cyan", "fg_black"),
+        **kwargs,
+    )
+
+    index = menu.show()
+
+    if index is None:
+        sys.exit(0)
+
+    return options[index]
 
 
 class Utils:


### PR DESCRIPTION
Currently we're using `TerminalMenu` all over the place. Since we can also add styling I thought we should make a function, so we can get uniform styling. Also then we only need to handle special inputs like `q` and `ctrl+c` only in one place.